### PR TITLE
Address nightly build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By the end of this tutorial, you should be able to use core features of `xbatche
 
 ## Authors
 
-[Christopher Dupuis](@cmdupuis3), [Anirban Sinha](@anirban89), [Ryan Abernathey](@rabernat)
+[Christopher Dupuis](https://github.com/cmdupuis3), [Anirban Sinha](https://github.com/anirban89), [Ryan Abernathey](https://github.com/rabernat)
 
 ### Contributors
 


### PR DESCRIPTION
Fixes some links

https://storage.googleapis.com/download/storage/v1/b/pangeo-cesm-pop/o/control%2F.zgroup?alt=media cannot be accessed because "Bucket is a requester pays bucket but no user project provided." at line `prepare_data(sc5, 200, 1000, 1000, 200)` in `surface_currents.ipynb`

We'll have to add your Google Cloud Platform Project ID as a GitHub secret. If you email it to me I can deal with that for you, or do it together in a call.